### PR TITLE
Make version use string with single quotes

### DIFF
--- a/tbats/__init__.py
+++ b/tbats/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.4"
+__version__ = '1.1.4'
 
 import tbats.abstract as abstract
 import tbats.bats as bats


### PR DESCRIPTION
It seems that some regex is matching only on single quotes, throwing errors when installing if there are double quotes.